### PR TITLE
When being removed from the superview, willMoveToSuperview:nil was be…

### DIFF
--- a/AutocompleteTextfieldSwift/AutoCompleteTextField/AutoCompleteTextField.swift
+++ b/AutocompleteTextfieldSwift/AutoCompleteTextField/AutoCompleteTextField.swift
@@ -74,7 +74,9 @@ public class AutoCompleteTextField:UITextField {
     public override func willMoveToSuperview(newSuperview: UIView?) {
         super.willMoveToSuperview(newSuperview)
         commonInit()
-        setupAutocompleteTable(newSuperview!)
+        if let superview = newSuperview {
+            setupAutocompleteTable(superview)
+        }
     }
     
     private func commonInit(){


### PR DESCRIPTION
…ing called and causing a crash.

By unwrapping the optional safely, we fixed this bug.
